### PR TITLE
added missing textCapSentences tag to EditText

### DIFF
--- a/app/src/main/res/layout/activity_edit_note.xml
+++ b/app/src/main/res/layout/activity_edit_note.xml
@@ -55,7 +55,7 @@
                     android:id="@+id/noteEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:inputType="text|textMultiLine"
+                    android:inputType="text|textMultiLine|textCapSentences"
                     android:fontFamily="monospace"
                     android:textSize="24dp"
                     android:layout_margin="0dp"


### PR DESCRIPTION
added missing textCapSentences tag to EditText in EditNoteActivity so that sentences automatically start with caps.