### PR TITLE
bugfix for empty newline removal

### DIFF
--- a/app/src/main/java/gt/com/gtnote/EditNoteActivity.java
+++ b/app/src/main/java/gt/com/gtnote/EditNoteActivity.java
@@ -6,7 +6,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.text.SpannableString;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.Menu;
@@ -552,7 +551,7 @@ public class EditNoteActivity extends AppCompatActivity {
             //meta.setColor();  //TODO
             meta.setLastEditTime(System.currentTimeMillis());
             
-            note.getNoteContent().setText(new SpannableString(noteEditText.getText()));
+            note.getNoteContent().setText(noteEditText.getText().toString());
 
             m_NoteManager.save(note);
             

--- a/app/src/main/java/gt/com/gtnote/Interfaces/NoteContent.java
+++ b/app/src/main/java/gt/com/gtnote/Interfaces/NoteContent.java
@@ -1,14 +1,12 @@
 package gt.com.gtnote.Interfaces;
 
-import android.text.Spanned;
-
 import java.util.List;
 
 import gt.com.gtnote.Models.SubModels.Resource;
 
 public interface NoteContent {
-    Spanned getText();
-    void setText(Spanned spanned);
+    String getText();
+    void setText(String text);
     void setResources(List<Resource> resources);
     List<Resource> getResources();
 }

--- a/app/src/main/java/gt/com/gtnote/MainActivity.java
+++ b/app/src/main/java/gt/com/gtnote/MainActivity.java
@@ -7,8 +7,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.text.SpannableString;
-import android.text.Spanned;
 import android.util.Log;
 import android.view.View;
 import android.view.Menu;
@@ -107,7 +105,7 @@ public class MainActivity extends AppCompatActivity implements OnNoteListener {
         // set data
         meta.setColor(Color.BLUE);
         meta.setTitle(titleString);
-        content.setText(new SpannableString(contentString));
+        content.setText(contentString);
 
         // write to file
         noteManager.save(note);
@@ -121,8 +119,7 @@ public class MainActivity extends AppCompatActivity implements OnNoteListener {
         // get note instance and read content from file
         note = noteManager.getById(id);
         if (note != null) {
-            Spanned spanned = note.getNoteContent().getText();  // reads from file
-            String loadedContentString = spanned.toString();
+            String loadedContentString = note.getNoteContent().getText();  // reads from file
             Log.d(TAG, String.format("test: loaded content string: '''%s'''", loadedContentString));
 
             if (loadedContentString.equals(contentString)) {

--- a/app/src/main/java/gt/com/gtnote/Models/LazyNoteContent.java
+++ b/app/src/main/java/gt/com/gtnote/Models/LazyNoteContent.java
@@ -1,9 +1,5 @@
 package gt.com.gtnote.Models;
 
-import android.os.Build;
-import android.text.Html;
-import android.text.Spanned;
-
 import java.util.List;
 
 import gt.com.gtnote.Interfaces.NoteContent;
@@ -14,7 +10,7 @@ import gt.com.gtnote.Models.SubModels.Resource;
  */
 class LazyNoteContent implements NoteContent {
     
-    private Spanned spanned;
+    private String text;
     private List<Resource> resources;
     private FilePointer filePointer;
     private boolean textLoaded;
@@ -30,21 +26,21 @@ class LazyNoteContent implements NoteContent {
      * @return the loaded content
      */
     @Override
-    public Spanned getText() {
+    public String getText() {
         if (!textLoaded) {
             loadText();
             textLoaded = true;
         }
-        return spanned;
+        return text;
     }
     
     /**
      * be careful: when you use this, the FilePointer's content will be ignored
-     * @param spanned
+     * @param text
      */
     @Override
-    public void setText(Spanned spanned) {
-        this.spanned = spanned;
+    public void setText(String text) {
+        this.text = text;
         textLoaded = true;
     }
     
@@ -59,13 +55,7 @@ class LazyNoteContent implements NoteContent {
     }
     
     private void loadText() {
-        // TODO: use an ImageGetter in Html.fromHtml()
         // https://stackoverflow.com/questions/37899856/html-fromhtml-is-deprecated-what-is-the-alternative/37899914
-        String source = filePointer.read();
-        if (Build.VERSION.SDK_INT >= 24) {
-            spanned = Html.fromHtml(source, Html.FROM_HTML_MODE_COMPACT);
-        } else {
-            spanned = Html.fromHtml(source);
-        }
+        text = filePointer.read();
     }
 }

--- a/app/src/main/java/gt/com/gtnote/Models/NoteManager.java
+++ b/app/src/main/java/gt/com/gtnote/Models/NoteManager.java
@@ -1,9 +1,5 @@
 package gt.com.gtnote.Models;
 
-import android.os.Build;
-import android.text.Html;
-import android.text.SpannableString;
-import android.text.Spanned;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -104,7 +100,7 @@ public class NoteManager {
                 System.currentTimeMillis(),
                 System.currentTimeMillis()
         );
-        NoteContent content = new PresentNoteContent(new SpannableString(""));
+        NoteContent content = new PresentNoteContent("");
         Note note = new Note(meta, content);
         insertNote(note);
         return note;
@@ -225,14 +221,7 @@ public class NoteManager {
      */
     private void saveContent(Note note) {
         
-        Spanned spanned = note.getNoteContent().getText();
-        String source = null;
-        if (Build.VERSION.SDK_INT >= 24) {
-            source = Html.toHtml(spanned, Html.TO_HTML_PARAGRAPH_LINES_CONSECUTIVE);
-            // maybe Html.TO_HTML_PARAGRAPH_LINES_INDIVIDUAL is better
-        } else {
-            source = Html.toHtml(spanned);
-        }
+        String source = note.getNoteContent().getText();
         
         String contentFilePath = filePathFromNoteId(note.getNoteMeta().getNoteId());
         fileIO.write(contentFilePath, source);

--- a/app/src/main/java/gt/com/gtnote/Models/PresentNoteContent.java
+++ b/app/src/main/java/gt/com/gtnote/Models/PresentNoteContent.java
@@ -1,7 +1,5 @@
 package gt.com.gtnote.Models;
 
-import android.text.Spanned;
-
 import java.util.List;
 
 import gt.com.gtnote.Interfaces.NoteContent;
@@ -13,21 +11,21 @@ import gt.com.gtnote.Models.SubModels.Resource;
  */
 class PresentNoteContent implements NoteContent {
     
-    private Spanned spanned;
+    private String text;
     private List<Resource> resources;
     
-    PresentNoteContent(Spanned spanned) {
-        this.spanned = spanned;
+    PresentNoteContent(String text) {
+        this.text = text;
     }
     
     @Override
-    public Spanned getText() {
-        return spanned;
+    public String getText() {
+        return text;
     }
     
     @Override
-    public void setText(Spanned spanned) {
-        this.spanned = spanned;
+    public void setText(String text) {
+        this.text = text;
     }
     
     @Override


### PR DESCRIPTION
related issue: https://github.com/Gegd99/gtnote/issues/43#issue-469038944

I basically replaced Spannable / Spanned with String.
- only String will be used internally, no HTML
- removed unnecessary HTML parsing (no idea why it was there in the first place)